### PR TITLE
Got rid of need for hackIngress function

### DIFF
--- a/lib/sg.js
+++ b/lib/sg.js
@@ -27,33 +27,6 @@ var PORT = '__PORT__';
 var CIDR = '__CIDR__';
 
 
-/**
- * the aws function ec2.authorizeSecurityGroupIngress appears to just not work...
- * this temporary hack creates a set of AWS command line instructions in a single 
- * bash script and executes them to set ingress rules on a given security group
- */
-var hackIngress = function(groupId, ipPermissions, out, cb) {
-  var ingress = 'aws ec2 authorize-security-group-ingress --group-id __GROUP_ID__ --protocol __PROTOCOL__ --port __PORT__ --cidr __CIDR__\n';
-  var script = '';
-  var rule = '';
-
-  script = 'export AWS_ACCESS_KEY_ID=' + _config.accessKeyId + '\n';
-  script += 'export AWS_SECRET_ACCESS_KEY=' + _config.secretAccessKey + '\n';
-  script += 'export AWS_DEFAULT_REGION=' + _config.region + '\n';
-  _.each(ipPermissions, function(perm) {
-    rule = ingress.replace(GROUP_ID, groupId);
-    rule = rule.replace(PROTOCOL, perm.IpProtocol);
-    rule = rule.replace(PORT, perm.FromPort);
-    rule = rule.replace(CIDR, perm.IpRanges[0].CidrIp);
-    script += rule;
-  });
-
-  fs.writeFileSync('/tmp/_hackingress.sh', script, 'utf8');
-  executor.exec(_mode, 'sh /tmp/_hackingress.sh', '/tmp', out, cb);
-};
-
-
-
 var handleGroup = function(system, container, out, cb) {
   var sg = container.specific;
   var match = false;
@@ -85,11 +58,10 @@ var handleGroup = function(system, container, out, cb) {
           c.nativeId = resp.GroupId;
           system.dirty = true;
           if (sg.IpPermissions) {
-            setTimeout(function() {
-              hackIngress(resp.GroupId, sg.IpPermissions, out, function() {
-                cb(err, system);
-              });
-            }, 10000);
+            var params = {GroupId : resp.GroupId, IpPermissions : sg.IpPermissions};
+            _ec2.authorizeSecurityGroupIngress(params, function (err, data) {
+              cb(err, system);
+            })
           }
         });
       });


### PR DESCRIPTION
It turns out the problem with the ec2.authorizeSecurityGroupIngress function was the parameters being passed to it. When passing the IpPermissions objects it will throw an error "Missing source GroupId" if any empty UserIdGroupPairs lists are passed. I tried this out with the sudc system which you can see in this [commit](https://github.com/darragh-hayes/sudc-system/commit/e4d5e341e986a0371269285bf2471af106f5878d). This kept the function happy.

Furthermore, the purpose of the UserIdGroupPairs list is to authorize traffic coming from specified security groups and/or users. According to the [docs](http://docs.aws.amazon.com/cli/latest/reference/ec2/authorize-security-group-ingress.html) it follows this syntax: 

``` js
"UserIdGroupPairs": 
[
...
      {
        "UserId": "string",
        "GroupName": "string",
        "GroupId": "string"
      }
...
]
//where GroupId is the only non-optional field
```

In the old hackIngress function we were building a script that would run this command for each permission:

``` bash
aws ec2 authorize-security-group-ingress --group-id __GROUP_ID__ --protocol __PROTOCOL__ --port __PORT__ --cidr __CIDR__
```

The thing is, the baked in parameters mean you can't actually make use of the UserIdGroupPairs which can be pretty useful in their own right. The above command just ignores them. My changes allow for the use of the UserIdGroupPairs list as long as it isn't empty and any object passed has the required GroupId field. Now there isn't a 10 second long setTimeout either.
