### PR TITLE
Use defaultVpcId if a specific VpcId is not present

### DIFF
--- a/lib/sg.js
+++ b/lib/sg.js
@@ -34,7 +34,7 @@ var handleGroup = function(system, container, out, cb) {
     if (!match || (err && err.name && -1 !== err.name.indexOf('NotFound'))) {
       _ec2.createSecurityGroup({Description: sg.Description,
                                 GroupName: container.id,
-                                VpcId: sg.VpcId}, function(err, resp) {
+                                VpcId: sg.VpcId || _config.defaultVpcId}, function(err, resp) {
         if (err) {
           if (-1 !== err.name.indexOf('InvalidGroup.Duplicate')) {
             return cb(null, system);


### PR DESCRIPTION
Part of https://github.com/nearform/nscale-kernel/pull/92
